### PR TITLE
Bump version to 2.0.2 for first AsciiDoc version.

### DIFF
--- a/header.adoc
+++ b/header.adoc
@@ -52,6 +52,7 @@ endif::[]
 - Removed references to tail-calls in jump classifications in <<sec:InstructionInterfaceRequirements>>. +
 - Corrected typos where `lrid` was inadvertently refered to by an earlier name (`index`) in <<sec:data-loadstore>>. +
 - Corrected reference decoder in <<Decoder>> to cover a corner-case related to trap returns.
+|2.0.2 |First version in AsciiDoc format.
 |===
 
 [preface]

--- a/header.adoc
+++ b/header.adoc
@@ -2,8 +2,8 @@
 Gajinder Panesar <gajinder.panesar@gmail.com>, Iain Robertson <iain.robertson@siemens.com>
 :description: Efficient Trace for RISC-V
 :company: RISC-V.org
-:revdate: January 5, 2024
-:revnumber: 2.0.1
+:revdate: March 5, 2024
+:revnumber: 2.0.2
 :url-riscv: http://riscv.org
 :doctype: book
 :pdf-theme: docs-resources/themes/riscv-pdf.yml


### PR DESCRIPTION
Just bumping the version to 2.0.2 to differentiate between the final LaTeX based document and the first AsciiDoc based document.