### PR TITLE
referenceFlow/scripts: fix NoneType print

### DIFF
--- a/referenceFlow/scripts/decoder_model.py
+++ b/referenceFlow/scripts/decoder_model.py
@@ -85,7 +85,7 @@ class TeInst:
                 if hasattr(self, fieldname) and getattr(self, fieldname) is not None
             )
         )
-        if hasattr(self, "address"):
+        if hasattr(self, "address") and self.address != None:
             fields += ", address=0x%lx" % self.address
         return "{}({})".format(self.__class__.__name__, fields)
 


### PR DESCRIPTION
When debug mode is enable, an error will occur when the address is nonetype